### PR TITLE
Use wally-package-types to export packages types

### DIFF
--- a/server/wally-server-startup.sh
+++ b/server/wally-server-startup.sh
@@ -4,4 +4,6 @@ for arg in "$@"; do echo "$arg" >> wally.toml; done
 cat wally.toml
 wally install
 mkdir Packages ServerPackages
+rojo sourcemap > sourcemap.json
+wally-package-types --sourcemap sourcemap.json Packages
 rojo serve --address 0.0.0.0

--- a/server/wally-server.Dockerfile
+++ b/server/wally-server.Dockerfile
@@ -7,6 +7,8 @@ RUN wget -q https://github.com/rojo-rbx/rojo/releases/download/v7.2.1/rojo-7.2.1
 RUN unzip rojo-7.2.1-linux.zip
 RUN wget -q https://github.com/UpliftGames/wally/releases/download/v0.3.1/wally-0.3.1-linux.zip
 RUN unzip wally-0.3.1-linux.zip
+RUN wget -q https://github.com/JohnnyMorganz/wally-package-types/releases/download/v1.1.1/wally-package-types-linux.zip
+RUN unzip wally-package-types-linux.zip
 
 FROM debian:stable-20220912-slim
 
@@ -16,6 +18,7 @@ RUN apt-get install -y ca-certificates
 
 COPY --from=download-deps /rojo /bin/rojo
 COPY --from=download-deps /wally /bin/wally
+COPY --from=download-deps /wally-package-types /bin/wally-package-types
 RUN chmod +x /bin/wally
 
 COPY ./base-project/* /srv/project/


### PR DESCRIPTION
Uses https://github.com/JohnnyMorganz/wally-package-types to make the packages correctly export their types.